### PR TITLE
Adjusting local completed config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ docs/_build/
 
 # PyBuilder
 target/
+files/tmp/ansible
+files/tmp/ansible.log

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ apply:
 	docker run -it \
 	--rm \
 	-v $(PWD)/files/:/home/tmp/files \
+	-v $(PWD)/files/tmp:/tmp \
 	-w /home/tmp/files/ansible/ \
 	$(DOCKER_IMG):$(DOCKER_TAG) ansible-playbook pb.configuration.apply.yml 
 
@@ -26,6 +27,7 @@ backup:
 	docker run -it \
 	--rm \
 	-v $(PWD)/files/:/home/tmp/files \
+	-v $(PWD)/files/tmp:/tmp \
 	-w /home/tmp/files/ansible/ \
 	$(DOCKER_IMG):$(DOCKER_TAG) ansible-playbook pb.configuration.backup.yml 
 
@@ -33,6 +35,7 @@ bootstrap:
 	docker run -it \
 	--rm \
 	-v $(PWD)/files/:/home/tmp/files \
+	-v $(PWD)/files/tmp:/tmp \
 	-w /home/tmp/files/ansible/ \
 	$(DOCKER_IMG):$(DOCKER_TAG) ansible-playbook pb.configuration.bootstrap.yml 
 
@@ -43,6 +46,7 @@ config:
 	docker run -it \
 	--rm \
 	-v $(PWD)/files/:/home/tmp/files \
+	-v $(PWD)/files/tmp:/tmp \
 	-w /home/tmp/files/ansible/ \
 	$(DOCKER_IMG):$(DOCKER_TAG) ansible-playbook pb.configuration.build.yml
 
@@ -50,6 +54,7 @@ netbox-get:
 	docker run -it \
 	--rm \
 	-v $(PWD)/files/:/home/tmp/files \
+	-v $(PWD)/files/tmp:/tmp \
 	-w /home/tmp/files/ansible/ \
 	$(DOCKER_IMG):$(DOCKER_TAG) ansible-playbook pb.netbox.retrieve.info.yml
 
@@ -57,13 +62,7 @@ shell:
 	docker run -it \
 	--rm \
 	-v $(PWD)/files/:/home/tmp/files \
+	-v $(PWD)/files/tmp:/tmp \
 	-w /home/tmp/files/ansible/ \
 	$(DOCKER_IMG):$(DOCKER_TAG) /bin/sh
 
-# ### side note: simplifying by removing local ansible execution
-# ### until someone declares that they want it.
-# ### will push foward with only docker-based deployments for now
-
-# run:
-# 	cd $(PWD)/files/ansible/; \
-# 	ansible-playbook pb.configuration.network.yml 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,23 @@
+[defaults]
+hash_behaviour=merge
+host_key_checking=False
+host_key_auto_add = True
+retry_files_enabled=False # for the sake of everything good, stop creating these uesless files
+forks = 15
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /tmp
+stdout_callback = yaml
+library = ./files/ansible/library
+callback_whitelist = profile_tasks,jsnapy
+roles_path = ./files/ansible/roles:/etc/ansible/roles
+deprecation_warnings = False
+# inventory = ./inventory.yml
+log_path=/tmp/ansible.log
+ansible_debug = True
+timeout = 240
+# interpreter_python = /opt/app-root/bin/python
+nocows = 1
+
+[persistent_connection]
+command_timeout = 45

--- a/files/ansible/group_vars/all/files_and_directories.yml
+++ b/files/ansible/group_vars/all/files_and_directories.yml
@@ -2,37 +2,42 @@
 ### -------------------------------------------------
 ### DIRECTORIES TO BE USED IN JUNIPER_STANZA ROLES
 ### -------------------------------------------------
-# to be the root of all configuration building during the playbook run
+# directories to hold configuration files as they're generated
 temporary_directory: "/tmp/ansible/"
-
-# hosts each configuration elementer per device
 build_directory: "{{ temporary_directory }}/{{ inventory_hostname }}/tmp"
+build_completed_file: "{{ temporary_directory }}/{{ inventory_hostname }}.conf"
 
-# local director to hold the final configuration product
+# completed configuration is stored in the project's local folder
 configuration_directory: "config"
+completed_config_file: "{{ configuration_directory }}/{{ inventory_hostname }}.conf"
 
-# name of the actual configuration file that's pushed to the remote device
-configuration_file: "{{ inventory_hostname }}.conf"
+### -------------------------------------------------
+### BACKUP DIRECTORY FOR CONFIGS AND FACTS
+### -------------------------------------------------
 
-# complete path of the completed configuration file
-completed_config_file: "{{ configuration_directory }}/{{ configuration_file }}"
-
-# configuration to store data that has been retreived from the boxes. brownfield only
+# directories to hold retreived configurations
 backup_directory: "./backup/{{ inventory_hostname }}"
+backup_facts_directory: "{{ backup_directory }}/facts"
+backup_config_directory: "{{ backup_directory }}/config"
 
-# configuration to store data that has been retreived from the boxes. brownfield only
-backup_config_directory: "./backup/{{ inventory_hostname }}/config"
-
-# backup configuration file that has been retreived from the boxes. brownfield only
+# backup configuration file
 backup_file: "{{ backup_config_directory }}/{{ inventory_hostname }}.conf"
 
-# declared when you want to transfer a brownfield site to overwrite local yaml files
-host_vars_directory: "./host_vars/{{ inventory_hostname }}"
-
-# host facts retrieved from devices and saved offline
-backup_facts_directory: "{{ backup_directory }}/facts"
-
-ansible_python_interpreter: "{{ ansible_playbook_python }}"
+### -------------------------------------------------
+### BOOTSTRAP CONFIGS
+### -------------------------------------------------
 
 bootstrap_config_dir: "./backup/bootstrap"
 bootstrap_config_file: "{{ bootstrap_config_dir }}/{{ inventory_hostname }}.conf"
+
+### -------------------------------------------------
+### CHANGE PYTHON ENVIRONMENT
+### -------------------------------------------------
+ansible_python_interpreter: "{{ ansible_playbook_python }}"
+
+### -------------------------------------------------
+### NETBOX WORK
+### -------------------------------------------------
+
+netbox_vars_directory: "./host_vars/{{ inventory_hostname }}"
+interface_yaml: "{{ netbox_vars_directory }}/interfaces.yml"

--- a/files/ansible/group_vars/all/files_and_directories.yml
+++ b/files/ansible/group_vars/all/files_and_directories.yml
@@ -4,8 +4,10 @@
 ### -------------------------------------------------
 # directories to hold configuration files as they're generated
 temporary_directory: "/tmp/ansible/"
-build_directory: "{{ temporary_directory }}/{{ inventory_hostname }}/tmp"
-build_completed_file: "{{ temporary_directory }}/{{ inventory_hostname }}.conf"
+build_directory: "{{ temporary_directory }}/{{ inventory_hostname }}"
+build_directory_temp: "{{ build_directory }}/tmp"
+build_directory_complete: "{{ build_directory }}/complete"
+build_completed_file: "{{ build_directory_complete }}/{{ inventory_hostname }}.conf"
 
 # completed configuration is stored in the project's local folder
 configuration_directory: "config"

--- a/files/ansible/host_vars/access-sw1/forwarding_options.yml
+++ b/files/ansible/host_vars/access-sw1/forwarding_options.yml
@@ -1,0 +1,5 @@
+configuration:
+  forwarding_options:
+    storm_control_profiles:
+      all: null
+      name: default

--- a/files/ansible/host_vars/access-sw1/interfaces.yml
+++ b/files/ansible/host_vars/access-sw1/interfaces.yml
@@ -13,17 +13,6 @@ configuration:
               vlan:
                 members: "vlan_1"
 
-      # - name: xe-0/0/1
-      #   mtu: 9100
-      #   unit:
-      #     name: "0"
-      #     description: "Connected to guest-1"
-      #     family:
-      #       ethernet_switching:
-      #         interface_mode: access
-      #         vlan:
-      #           members: "vlan_2"
-
       - name: xe-0/0/4
         description: "Connected to dist-sw1 (member of ae3)"
         ether_options:
@@ -35,18 +24,6 @@ configuration:
         ether_options:
           ieee_802.3ad:
             bundle: ae3
-
-      # - name: xe-0/0/8
-      #   description: "Connected to dist-sw3 (member of ae3)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae3
-
-      # - name: xe-0/0/10
-      #   description: "Connected to dist-sw4 (member of ae3)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae3
 
       # ### AE INTERFACES
       - name: ae3

--- a/files/ansible/host_vars/access-sw2/interfaces.yml
+++ b/files/ansible/host_vars/access-sw2/interfaces.yml
@@ -13,17 +13,6 @@ configuration:
               vlan:
                 members: "vlan_2"
 
-      # - name: xe-0/0/1
-      #   mtu: 9100
-      #   unit:
-      #     name: "0"
-      #     description: "Connected to guest-2"
-      #     family:
-      #       ethernet_switching:
-      #         interface_mode: access
-      #         vlan:
-      #           members: "vlan_2"
-
       - name: xe-0/0/5
         description: "Connected to dist-sw1 (member of ae3)"
         ether_options:
@@ -35,18 +24,6 @@ configuration:
         ether_options:
           ieee_802.3ad:
             bundle: ae3
-
-      # - name: xe-0/0/9
-      #   description: "Connected to dist-sw3 (member of ae3)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae3
-
-      # - name: xe-0/0/11
-      #   description: "Connected to dist-sw4 (member of ae3)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae3
 
       # ### AE INTERFACES
       - name: ae3

--- a/files/ansible/host_vars/access-sw3/interfaces.yml
+++ b/files/ansible/host_vars/access-sw3/interfaces.yml
@@ -13,29 +13,6 @@ configuration:
               vlan:
                 members: "vlan_3"
 
-      # - name: xe-0/0/1
-      #   mtu: 9100
-      #   unit:
-      #     name: "0"
-      #     description: "Connected to guest-3"
-      #     family:
-      #       ethernet_switching:
-      #         interface_mode: access
-      #         vlan:
-      #           members: "vlan_2"
-
-      # - name: xe-0/0/6
-      #   description: "Connected to dist-sw1 (member of ae3)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae3
-
-      # - name: xe-0/0/8
-      #   description: "Connected to dist-sw2 (member of ae3)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae3
-
       - name: xe-0/0/10
         description: "Connected to dist-sw3 (member of ae3)"
         ether_options:

--- a/files/ansible/host_vars/access-sw4/interfaces.yml
+++ b/files/ansible/host_vars/access-sw4/interfaces.yml
@@ -13,34 +13,11 @@ configuration:
               vlan:
                 members: "vlan_1"
 
-      # - name: xe-0/0/1
-      #   mtu: 9100
-      #   unit:
-      #     name: "0"
-      #     description: "Connected to guest-4"
-      #     family:
-      #       ethernet_switching:
-      #         interface_mode: access
-      #         vlan:
-      #           members: "vlan_2"
-
       - name: xe-0/0/3
         description: "Connected to dist-sw4 (member of ae3)"
         ether_options:
           ieee_802.3ad:
             bundle: ae3
-
-      # - name: xe-0/0/7
-      #   description: "Connected to dist-sw1 (member of ae3)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae3
-
-      # - name: xe-0/0/9
-      #   description: "Connected to dist-sw2 (member of ae3)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae3
 
       - name: xe-0/0/11
         description: "Connected to dist-sw3 (member of ae3)"

--- a/files/ansible/host_vars/dist-sw1/interfaces.yml
+++ b/files/ansible/host_vars/dist-sw1/interfaces.yml
@@ -38,18 +38,6 @@ configuration:
           ieee_802.3ad:
             bundle: ae22
 
-      # - name: xe-0/0/6
-      #   description: "Connected to access-sw3 (member of ae23)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae23
-
-      # - name: xe-0/0/7
-      #   description: "Connected to access-sw4 (member of ae24)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae24
-
       # ### AE INTERFACES
       - name: ae11
         description: "Connected to core-sw1 (members: xe-0/0/0 / xe-0/0/1)"
@@ -128,52 +116,6 @@ configuration:
                     - vlan_1 
                     - vlan_2 
                     - vlan_3
-
-      # - name: ae23
-      #   description: "Connected to access-sw3 (members: xe-0/0/6)"
-      #   apply_groups:
-      #     - AE_MTU_JUMBO
-      #     - AE_LACP_BOND
-      #   aggregated_ether_options:
-      #     lacp:
-      #       active: null
-      #       system_id: 00:40:00:00:00:03
-      #   esi:
-      #     all_active: null
-      #     identifier: 00:11:11:11:11:11:11:11:11:03
-      #   unit:
-      #     - name: "0"
-      #       family:
-      #         ethernet_switching:
-      #           interface_mode: trunk
-      #           vlan:
-      #             members:
-      #               - vlan_1 
-      #               - vlan_2 
-      #               - vlan_3
-
-      # - name: ae24
-      #   description: "Connected to access-sw4 (members: xe-0/0/7)"
-      #   apply_groups:
-      #     - AE_MTU_JUMBO
-      #     - AE_LACP_BOND
-      #   aggregated_ether_options:
-      #     lacp:
-      #       active: null
-      #       system_id: 00:40:00:00:00:04
-      #   esi:
-      #     all_active: null
-      #     identifier: 00:11:11:11:11:11:11:11:11:04
-      #   unit:
-      #     - name: "0"
-      #       family:
-      #         ethernet_switching:
-      #           interface_mode: trunk
-      #           vlan:
-      #             members:
-      #               - vlan_1 
-      #               - vlan_2 
-      #               - vlan_3
 
       # ### MGMT INTERFACE
       - name: em0

--- a/files/ansible/host_vars/dist-sw2/interfaces.yml
+++ b/files/ansible/host_vars/dist-sw2/interfaces.yml
@@ -38,18 +38,6 @@ configuration:
           ieee_802.3ad:
             bundle: ae22
 
-      # - name: xe-0/0/8
-      #   description: "Connected to access-sw3 (member of ae23)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae23
-
-      # - name: xe-0/0/9
-      #   description: "Connected to access-sw4 (member of ae24)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae24
-
       # ### AE INTERFACES
       - name: ae11
         description: "Connected to core-sw1 (members: xe-0/0/2 / xe-0/0/3)"
@@ -128,52 +116,6 @@ configuration:
                     - vlan_1 
                     - vlan_2 
                     - vlan_3
-
-      # - name: ae23
-      #   description: "Connected to access-sw3 (members: xe-0/0/8)"
-      #   apply_groups:
-      #     - AE_MTU_JUMBO
-      #     - AE_LACP_BOND
-      #   aggregated_ether_options:
-      #     lacp:
-      #       active: null
-      #       system_id: 00:40:00:00:00:03
-      #   esi:
-      #     all_active: null
-      #     identifier: 00:11:11:11:11:11:11:11:11:03
-      #   unit:
-      #     - name: "0"
-      #       family:
-      #         ethernet_switching:
-      #           interface_mode: trunk
-      #           vlan:
-      #             members:
-      #               - vlan_1 
-      #               - vlan_2 
-      #               - vlan_3
-
-      # - name: ae24
-      #   description: "Connected to access-sw4 (members: xe-0/0/9)"
-      #   apply_groups:
-      #     - AE_MTU_JUMBO
-      #     - AE_LACP_BOND
-      #   aggregated_ether_options:
-      #     lacp:
-      #       active: null
-      #       system_id: 00:40:00:00:00:04
-      #   esi:
-      #     all_active: null
-      #     identifier: 00:11:11:11:11:11:11:11:11:04
-      #   unit:
-      #     - name: "0"
-      #       family:
-      #         ethernet_switching:
-      #           interface_mode: trunk
-      #           vlan:
-      #             members:
-      #               - vlan_1 
-      #               - vlan_2 
-      #               - vlan_3
 
       # ### MGMT INTERFACE
       - name: em0

--- a/files/ansible/host_vars/dist-sw3/interfaces.yml
+++ b/files/ansible/host_vars/dist-sw3/interfaces.yml
@@ -26,18 +26,6 @@ configuration:
           ieee_802.3ad:
             bundle: ae12
 
-      # - name: xe-0/0/8
-      #   description: "Connected to access-sw1 (member of ae21)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae21
-
-      # - name: xe-0/0/9
-      #   description: "Connected to access-sw2 (member of ae22)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae22
-
       - name: xe-0/0/10
         description: "Connected to access-sw3 (member of ae23)"
         ether_options:
@@ -82,52 +70,6 @@ configuration:
             inet:
               address:
                 name: "172.16.2.5/31"
-
-      # - name: ae21
-      #   description: "Connected to access-sw1 (members: xe-0/0/8)"
-      #   apply_groups:
-      #     - AE_MTU_JUMBO
-      #     - AE_LACP_BOND
-      #   aggregated_ether_options:
-      #     lacp:
-      #       active: null
-      #       system_id: 00:40:00:00:00:01
-      #   esi:
-      #     all_active: null
-      #     identifier: 00:11:11:11:11:11:11:11:11:01
-      #   unit:
-      #     - name: "0"
-      #       family:
-      #         ethernet_switching:
-      #           interface_mode: trunk
-      #           vlan:
-      #             members:
-      #               - vlan_1 
-      #               - vlan_2 
-      #               - vlan_3
-
-      # - name: ae22
-      #   description: "Connected to access-sw2 (members: xe-0/0/9)"
-      #   apply_groups:
-      #     - AE_MTU_JUMBO
-      #     - AE_LACP_BOND
-      #   aggregated_ether_options:
-      #     lacp:
-      #       active: null
-      #       system_id: 00:40:00:00:00:02
-      #   esi:
-      #     all_active: null
-      #     identifier: 00:11:11:11:11:11:11:11:11:02
-      #   unit:
-      #     - name: "0"
-      #       family:
-      #         ethernet_switching:
-      #           interface_mode: trunk
-      #           vlan:
-      #             members:
-      #               - vlan_1 
-      #               - vlan_2 
-      #               - vlan_3
 
       - name: ae23
         description: "Connected to access-sw3 (members: xe-0/0/10)"

--- a/files/ansible/host_vars/dist-sw4/interfaces.yml
+++ b/files/ansible/host_vars/dist-sw4/interfaces.yml
@@ -2,13 +2,13 @@ configuration:
   interfaces:
     interface:
       # ### PHYSICAL INTERFACES
-      - name: xe-0/0/1
+      - name: xe-0/0/2
         description: "Connected to access-sw3 (member of ae23)"
         ether_options:
           ieee_802.3ad:
             bundle: ae23
 
-      - name: xe-0/0/2
+      - name: xe-0/0/3
         description: "Connected to access-sw4 (member of ae24)"
         ether_options:
           ieee_802.3ad:

--- a/files/ansible/host_vars/dist-sw4/interfaces.yml
+++ b/files/ansible/host_vars/dist-sw4/interfaces.yml
@@ -38,18 +38,6 @@ configuration:
           ieee_802.3ad:
             bundle: ae12
 
-      # - name: xe-0/0/10
-      #   description: "Connected to access-sw1 (member of ae21)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae21
-
-      # - name: xe-0/0/11
-      #   description: "Connected to access-sw2 (member of ae22)"
-      #   ether_options:
-      #     ieee_802.3ad:
-      #       bundle: ae22
-
       # ### AE INTERFACES
       - name: ae11
         description: "Connected to core-sw1 (members: xe-0/0/4 / xe-0/0/5)"
@@ -82,52 +70,6 @@ configuration:
             inet:
               address:
                 name: "172.16.2.7/31"
-
-      # - name: ae21
-      #   description: "Connected to access-sw1 (members: xe-0/0/8)"
-      #   apply_groups:
-      #     - AE_MTU_JUMBO
-      #     - AE_LACP_BOND
-      #   aggregated_ether_options:
-      #     lacp:
-      #       active: null
-      #       system_id: 00:40:00:00:00:01
-      #   esi:
-      #     all_active: null
-      #     identifier: 00:11:11:11:11:11:11:11:11:01
-      #   unit:
-      #     - name: "0"
-      #       family:
-      #         ethernet_switching:
-      #           interface_mode: trunk
-      #           vlan:
-      #             members:
-      #               - vlan_1 
-      #               - vlan_2 
-      #               - vlan_3
-
-      # - name: ae22
-      #   description: "Connected to access-sw2 (members: xe-0/0/9)"
-      #   apply_groups:
-      #     - AE_MTU_JUMBO
-      #     - AE_LACP_BOND
-      #   aggregated_ether_options:
-      #     lacp:
-      #       active: null
-      #       system_id: 00:40:00:00:00:02
-      #   esi:
-      #     all_active: null
-      #     identifier: 00:11:11:11:11:11:11:11:11:02
-      #   unit:
-      #     - name: "0"
-      #       family:
-      #         ethernet_switching:
-      #           interface_mode: trunk
-      #           vlan:
-      #             members:
-      #               - vlan_1 
-      #               - vlan_2 
-      #               - vlan_3
 
       - name: ae23
         description: "Connected to access-sw3 (members: xe-0/0/10)"

--- a/files/ansible/pb.configuration.apply.yml
+++ b/files/ansible/pb.configuration.apply.yml
@@ -27,8 +27,8 @@
     - name: display multiple file contents
       debug: 
         msg: "{{ hostvars.inventory_hostname }}"
-      with_file:
-        - "{{ completed_config_file }}"
+      # with_file:
+      #   - "{{ completed_config_file }}"
 
 ### ---------------------------------------------------------------------------
 ### VALIDATE, DIFF, AND APPLY CONFIGURATION TO DEVICES

--- a/files/ansible/pb.configuration.apply.yml
+++ b/files/ansible/pb.configuration.apply.yml
@@ -37,6 +37,6 @@
   connection: local
   gather_facts: False
   roles:
-    # - { role: push_config/diff }
-    # - { role: push_config/check }
+    - { role: push_config/diff }
+    - { role: push_config/check }
     - { role: push_config/apply }

--- a/files/ansible/pb.configuration.apply.yml
+++ b/files/ansible/pb.configuration.apply.yml
@@ -20,14 +20,15 @@
 ### DEBUGGING A GENERATED CONFIGURATION
 ### ---------------------------------------------------------------------------
 
-# - hosts: leaf1
-#   connection: local
-#   gather_facts: False
-#   tasks:
-#     - name: display multiple file contents
-#       debug: var=item
-#       with_file:
-#         - "{{ completed_config_file }}"
+- hosts: access-sw1
+  connection: local
+  gather_facts: False
+  tasks:
+    - name: display multiple file contents
+      debug: 
+        msg: "{{ hostvars.inventory_hostname }}"
+      with_file:
+        - "{{ completed_config_file }}"
 
 ### ---------------------------------------------------------------------------
 ### VALIDATE, DIFF, AND APPLY CONFIGURATION TO DEVICES

--- a/files/ansible/pb.configuration.apply.yml
+++ b/files/ansible/pb.configuration.apply.yml
@@ -37,6 +37,6 @@
   connection: local
   gather_facts: False
   roles:
-    - { role: push_config/diff }
-    - { role: push_config/check }
+    # - { role: push_config/diff }
+    # - { role: push_config/check }
     - { role: push_config/apply }

--- a/files/ansible/pb.configuration.apply.yml
+++ b/files/ansible/pb.configuration.apply.yml
@@ -26,7 +26,7 @@
   tasks:
     - name: display multiple file contents
       debug: 
-        msg: "{{ hostvars.inventory_hostname }}"
+        msg: "{{ hostvars }}"
       # with_file:
       #   - "{{ completed_config_file }}"
 

--- a/files/ansible/roles/assemble_config/tasks/main.yml
+++ b/files/ansible/roles/assemble_config/tasks/main.yml
@@ -5,19 +5,20 @@
     state: directory
   run_once: true
 
-- name: "assemble configurations and copy to project's config folder for backup purposes"
+
+- name: "assemble configurations to temp completed folder"
   assemble: 
-    src: "{{ build_directory }}"
-    dest: "{{ playbook_dir }}/{{ completed_config_file }}"
+    src: "{{ build_directory_temp }}"
+    dest: "{{ build_completed_file }}"
 
 - name: Remove blank lines between matches
   lineinfile:
-    path: "{{ completed_config_file }}"
+    path: "{{ build_completed_file }}"
     regexp: '(^\s*$)'
     state: absent
 
-- name: "copy completed config file to /tmp/ansible directory for Ansible AWX to apply"
+- name: "copy completed config file to project's config directory backup purposes"
   copy: 
-    src: "{{ completed_config_file }}"
-    dest: "{{ build_completed_file}}"
+    src: "{{ build_completed_file }}"
+    dest: "{{ playbook_dir }}/{{ completed_config_file}}"
     backup: yes

--- a/files/ansible/roles/assemble_config/tasks/main.yml
+++ b/files/ansible/roles/assemble_config/tasks/main.yml
@@ -19,6 +19,6 @@
 - name: "copy completed config file to /tmp/ansible directory for Ansible AWX to apply"
   copy: 
     src: "{{ completed_config_file }}"
-    dest: "{{ build_completed_file}} "
+    dest: "{{ build_completed_file}}"
     backup: yes
     mode: '0600'

--- a/files/ansible/roles/assemble_config/tasks/main.yml
+++ b/files/ansible/roles/assemble_config/tasks/main.yml
@@ -5,7 +5,7 @@
     state: directory
   run_once: true
 
-- name: assemble configurations and copy to configuration
+- name: "assemble configurations and copy to project's config folder for backup purposes"
   assemble: 
     src: "{{ build_directory }}"
     dest: "{{ playbook_dir }}/{{ completed_config_file }}"
@@ -15,3 +15,10 @@
     path: "{{ completed_config_file }}"
     regexp: '(^\s*$)'
     state: absent
+
+- name: "copy completed config file to /tmp/ansible directory for Ansible AWX to apply"
+  copy: 
+    src: "{{ completed_config_file }}"
+    dest: "{{ build_completed_file}} "
+    backup: yes
+    mode: '0600'

--- a/files/ansible/roles/assemble_config/tasks/main.yml
+++ b/files/ansible/roles/assemble_config/tasks/main.yml
@@ -21,4 +21,3 @@
     src: "{{ completed_config_file }}"
     dest: "{{ build_completed_file}}"
     backup: yes
-    mode: '0600'

--- a/files/ansible/roles/build_config_stanza/access/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/access/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building access configuration
   template:
     src: "access.j2"
-    dest: "{{ build_directory }}/17_access.part"
+    dest: "{{ build_directory_temp }}/17_access.part.conf"

--- a/files/ansible/roles/build_config_stanza/apply_groups/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/apply_groups/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building apply_groups configuration
   template:
     src: "apply_groups.j2"
-    dest: "{{ build_directory }}/02_apply_groups.part"
+    dest: "{{ build_directory_temp }}/02_apply_groups.part.conf"

--- a/files/ansible/roles/build_config_stanza/chassis/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/chassis/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building chassis configuration
   template:
     src: "chassis.j2"
-    dest: "{{ build_directory }}/05_chassis.part"
+    dest: "{{ build_directory_temp }}/05_chassis.part.conf"

--- a/files/ansible/roles/build_config_stanza/class_of_service/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/class_of_service/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building class_of_service configuration
   template:
     src: "class_of_service.j2"
-    dest: "{{ build_directory }}/13_class_of_service.part"
+    dest: "{{ build_directory_temp }}/13_class_of_service.part.conf"

--- a/files/ansible/roles/build_config_stanza/event_options/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/event_options/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building event_options configuration
   template:
     src: "event_options.j2"
-    dest: "{{ build_directory }}/13_event_options.part"
+    dest: "{{ build_directory_temp }}/13_event_options.part.conf"

--- a/files/ansible/roles/build_config_stanza/firewall/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/firewall/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building firewall configuration
   template:
     src: "firewall.j2"
-    dest: "{{ build_directory }}/14_firewall.part"
+    dest: "{{ build_directory_temp }}/14_firewall.part.conf"

--- a/files/ansible/roles/build_config_stanza/forwarding_options/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/forwarding_options/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building forwarding_options configuration
   template:
     src: "forwarding_options.j2"
-    dest: "{{ build_directory }}/09_forwarding_options.part"
+    dest: "{{ build_directory_temp }}/09_forwarding_options.part.conf"

--- a/files/ansible/roles/build_config_stanza/groups/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/groups/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building groups configuration
   template:
     src: "groups.j2"
-    dest: "{{ build_directory }}/03_groups.part"
+    dest: "{{ build_directory_temp }}/03_groups.part.conf"

--- a/files/ansible/roles/build_config_stanza/interfaces/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/interfaces/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building interfaces configuration
   template:
     src: "interfaces.j2"
-    dest: "{{ build_directory }}/07_interfaces.part"
+    dest: "{{ build_directory_temp }}/07_interfaces.part.conf"

--- a/files/ansible/roles/build_config_stanza/poe/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/poe/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building poe configuration
   template:
     src: "poe.j2"
-    dest: "{{ build_directory }}/16_poe.part"
+    dest: "{{ build_directory_temp }}/16_poe.part.conf"

--- a/files/ansible/roles/build_config_stanza/policy_options/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/policy_options/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building policy_options configuration
   template:
     src: "policy_options.j2"
-    dest: "{{ build_directory }}/09_policy_options.part"
+    dest: "{{ build_directory_temp }}/09_policy_options.part.conf"

--- a/files/ansible/roles/build_config_stanza/protocols/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/protocols/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building protocols configuration
   template:
     src: "protocols.j2"
-    dest: "{{ build_directory }}/11_protocols.part"
+    dest: "{{ build_directory_temp }}/11_protocols.part.conf"

--- a/files/ansible/roles/build_config_stanza/routing_instances/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/routing_instances/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building routing_instances configuration
   template:
     src: "routing_instances.j2"
-    dest: "{{ build_directory }}/18_routing_instances.part"
+    dest: "{{ build_directory_temp }}/18_routing_instances.part.conf"

--- a/files/ansible/roles/build_config_stanza/routing_options/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/routing_options/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building routing_options configuration
   template:
     src: "routing_options.j2"
-    dest: "{{ build_directory }}/10_routing_options.part"
+    dest: "{{ build_directory_temp }}/10_routing_options.part.conf"

--- a/files/ansible/roles/build_config_stanza/security/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/security/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building security configuration
   template:
     src: "security.j2"
-    dest: "{{ build_directory }}/06_security.part"
+    dest: "{{ build_directory_temp }}/06_security.part.conf"

--- a/files/ansible/roles/build_config_stanza/services/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/services/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building services configuration
   template:
     src: "services.j2"
-    dest: "{{ build_directory }}/05_services.part"
+    dest: "{{ build_directory_temp }}/05_services.part.conf"

--- a/files/ansible/roles/build_config_stanza/snmp/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/snmp/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building snmp configuration
   template:
     src: "snmp.j2"
-    dest: "{{ build_directory }}/08_snmp.part"
+    dest: "{{ build_directory_temp }}/08_snmp.part.conf"

--- a/files/ansible/roles/build_config_stanza/switch_options/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/switch_options/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building switch_options configuration
   template:
     src: "switch_options.j2"
-    dest: "{{ build_directory }}/15_switch_options.part"
+    dest: "{{ build_directory_temp }}/15_switch_options.part.conf"

--- a/files/ansible/roles/build_config_stanza/system/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/system/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building system configuration
   template:
     src: "system.j2"
-    dest: "{{ build_directory }}/04_system.part"
+    dest: "{{ build_directory_temp }}/04_system.part.conf"

--- a/files/ansible/roles/build_config_stanza/version/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/version/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building version configuration
   template:
     src: "version.j2"
-    dest: "{{ build_directory }}/01_version.part"
+    dest: "{{ build_directory_temp }}/01_version.part.conf"

--- a/files/ansible/roles/build_config_stanza/virtual_chassis/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/virtual_chassis/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building virtual-chassis configuration
   template:
     src: "virtual_chassis.j2"
-    dest: "{{ build_directory }}/17_virtual_chassis.part"
+    dest: "{{ build_directory_temp }}/17_virtual_chassis.part.conf"

--- a/files/ansible/roles/build_config_stanza/vlans/tasks/main.yml
+++ b/files/ansible/roles/build_config_stanza/vlans/tasks/main.yml
@@ -2,4 +2,4 @@
 - name: building vlans configuration
   template:
     src: "vlans.j2"
-    dest: "{{ build_directory }}/19_vlans.part"
+    dest: "{{ build_directory_temp }}/19_vlans.part.conf"

--- a/files/ansible/roles/localhost-build-dirs/tasks/main.yaml
+++ b/files/ansible/roles/localhost-build-dirs/tasks/main.yaml
@@ -12,12 +12,12 @@
 ### -------------------------------------------------
 - name: remove previous temporary build directory
   file:
-    path: "{{ build_directory }}"
+    path: "{{ build_directory_temp }}"
     state: absent
 
 - name: create new temporary directory
   file:
-    path: "{{ build_directory }}"
+    path: "{{ build_directory_temp }}"
     state: directory
 
 ### -------------------------------------------------
@@ -27,3 +27,13 @@
   file:
     path: "{{ completed_config_file }}"
     state: absent
+
+- name: remove any previous build directory complete
+  file:
+    path: "{{ build_directory_complete }}"
+    state: absent
+
+- name: create new build_directory_complete
+  file:
+    path: "{{ build_directory_complete }}"
+    state: directory

--- a/files/ansible/roles/push_config/apply/tasks/main.yml
+++ b/files/ansible/roles/push_config/apply/tasks/main.yml
@@ -8,7 +8,7 @@
     user: "{{ provider_info.user }}"
     passwd: "{{ provider_info.passwd }}"
     # ssh_private_key_file: "{{ provider_info.ssh_private_key_file }}"
-    src: "{{ completed_config_file }}"
+    src: "{{ build_completed_file }}"
     timeout: 240
   register: result
   when: is_diff is defined

--- a/files/ansible/roles/push_config/check/tasks/main.yml
+++ b/files/ansible/roles/push_config/check/tasks/main.yml
@@ -8,7 +8,7 @@
     user: "{{ provider_info.user }}"
     passwd: "{{ provider_info.passwd }}"
     # ssh_private_key_file: "{{ provider_info.ssh_private_key_file }}"
-    src: "{{ completed_config_file }}"
+    src: "{{ build_completed_file }}"
     timeout: 240
     diff: false
     check: true

--- a/files/ansible/roles/push_config/diff/tasks/main.yml
+++ b/files/ansible/roles/push_config/diff/tasks/main.yml
@@ -63,7 +63,7 @@
     state: absent
 
 - name: "### Diff the committed against the local candidate"
-  command: "diff {{ backup_file }} {{ completed_config_file }}"
+  command: "diff {{ backup_file }} {{ build_completed_file }}"
   failed_when: "diff.rc > 1"
   register: diff
 


### PR DESCRIPTION
oof, AWX did NOT like how we were storing our completed configuration. this PR will allow for local and tower based deployments to coexists.

if you're curious, the project has two playbooks deployed in sequence within a workflow job template. the problem is that each playbook runs a seperate instance of the project in it's own unique namespace, so storing a completed config in the build instance does little to help the apply instance. 

we had to store the completed in the /tmp/ansible/{{ inventory_hostname}} path to make it exposed to both instances